### PR TITLE
Fix article URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This Readme is just the high level overview of the space; you should see the mos
 ## Motivational Use Cases
 
 - images
-  - https://mpost.io/best-100-stable-diffusion-prompts-the-most-beautiful-ai-text-to-image-prompts/it
+  - https://mpost.io/best-100-stable-diffusion-prompts-the-most-beautiful-ai-text-to-image-prompts
   - [3D MRI synthetic brain images](https://twitter.com/Warvito/status/1570691960792580096?) - [positive reception from neuroimaging statistician](https://twitter.com/danCMDstat/status/1572312699853312000?s=20&t=x-ouUbWA5n0-PxTGZcy2iA)
   - [multiplayer stable diffusion](https://huggingface.co/spaces/huggingface-projects/stable-diffusion-multiplayer?roomid=room-0)
 - video


### PR DESCRIPTION
for some reason having the `/it` postfix kept redirecting me to https://mpost.io/italian-fashion-brand-bulgari-enters-the-metaverse-with-zepeto-opens-a-virtual-pop-up-store/