### PR TITLE
Nix labml.ai (no longer available) and replace with Emergent Mind

### DIFF
--- a/Resources/Good AI Podcasts and Newsletters.md
+++ b/Resources/Good AI Podcasts and Newsletters.md
@@ -59,7 +59,7 @@ some of these are on youtube too, i dont really bother separating them. ⭐  rep
 	- https://eugeneyan.com/writing/
 	- https://lilianweng.github.io/
 - Aggregators
-	- Socially ranked papers weekly https://papers.labml.ai/papers/weekly (has [chrome extension](https://github.com/labmlai/chrome-extension)) - see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/)
+	- [Emergent Mind](https://www.emergentmind.com) (trending arXiv ML/AI papers with GPT-4-generated summaries and links to social media discussions) - see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/) see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/)
 	- Amplify/Sarah Catanzaro's PTK https://www.amplifypartners.com/projects-to-know
 	- Ben's Bites https://bensbites.beehiiv.com/
 	- TheSequence https://thesequence.substack.com/about


### PR DESCRIPTION
👋 The first link in the aggregators section was for [labml.ai](https://papers.labml.ai/papers/weekly) and a corresponding Chrome extension. The LabML site is no longer online, so I removed it and the link to the Chrome extension.

In its place, I'm humbly suggesting [Emergent Mind](https://www.emergentmind.com), my new arXiv AI/ML paper aggregator which @swyxio and I discussed on a call earlier today. Feel free to reword or move it lower in the list as you see fit. 