### PR TITLE
Add link to Eugene Yan's LLM Paper Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ The more advanced GPT3 reads have been split out to https://github.com/sw-yx/ai-
 	- scaling laws, (https://arxiv.org/abs/2001.08361)
 	- emergent abilities (https://arxiv.org/abs/2206.07682)
 	- language models can follow both flipped labels and semantically-unrelated labels (https://arxiv.org/abs/2303.03846)
+ - [LLM Paper Notes](https://github.com/eugeneyan/llm-paper-notes) - notes from the [Latent Space paper club](https://www.latent.space/about#%C2%A7components) by [Eugene Yan](https://eugeneyan.com/)
 - Transformers from scratch https://e2eml.school/transformers.html
 	- transformers vs LSTM https://medium.com/analytics-vidhya/why-are-lstms-struggling-to-matchup-with-transformers-a1cc5b2557e3
 	- transformer code walkthru https://twitter.com/mark_riedl/status/1555188022534176768


### PR DESCRIPTION
As you suggested during today's LLM Paper Club discussion, this PR adds a link to Eugene's LLM Paper notes.

I added it to the Advanced Reads section, but happy to move it elsewhere if you think there's a better spot for it.