### PR TITLE
remove redundant reference to arxiv sanity

### DIFF
--- a/Resources/Good AI Podcasts and Newsletters.md
+++ b/Resources/Good AI Podcasts and Newsletters.md
@@ -63,7 +63,7 @@ some of these are on youtube too, i dont really bother separating them. ⭐  rep
 	- https://eugeneyan.com/writing/
 	- https://lilianweng.github.io/
 - Aggregators
-	- [Emergent Mind](https://www.emergentmind.com) (trending arXiv ML/AI papers with GPT-4-generated summaries and links to social media discussions) - see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/) see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/)
+	- [Emergent Mind](https://www.emergentmind.com) (trending arXiv ML/AI papers with GPT-4-generated summaries and links to social media discussions) - see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/)
 	- Amplify/Sarah Catanzaro's PTK https://www.amplifypartners.com/projects-to-know
 	- Ben's Bites https://bensbites.beehiiv.com/
 	- TheSequence https://thesequence.substack.com/about


### PR DESCRIPTION
There is a line in AI Notes that reads:

[Emergent Mind](https://www.emergentmind.com/) (trending arXiv ML/AI papers with GPT-4-generated summaries and links to social media discussions) - see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/) see also Karpathy's [arxiv-sanity](https://arxiv-sanity-lite.com/)

Which has two identical references to arxiv sanity and so is likely a mistake.
This PR fixes that mistake by removing the second reference.