### PR TITLE
Add 4 AI engineering newsletters

### DIFF
--- a/Resources/Good AI Podcasts and Newsletters.md
+++ b/Resources/Good AI Podcasts and Newsletters.md
@@ -62,6 +62,7 @@ some of these are on youtube too, i dont really bother separating them. ⭐  rep
 	- Alan Thompson's Life Architect https://lifearchitect.substack.com (note [his credentials sus](https://news.ycombinator.com/item?id=35588974))
 	- Bradley Metrock (Deepgram) https://thisweekinvoice.substack.com/
 	- Carlos's Data Machina https://datamachina.substack.com/
+	- Conor Bronsdon's [Chain of Thought](https://newsletter.chainofthought.show/) - AI engineering interviews and writeups on agents, evals, and LLMOps
 	- Davis Blalock Arxiv roundup https://dblalock.substack.com/
 	- [Elvis Saravia's NLP Newsletter](https://nlp.elvissaravia.com/) - paper recap
 	- https://www.supervised.news/ is new but promising quality

--- a/Resources/Good AI Podcasts and Newsletters.md
+++ b/Resources/Good AI Podcasts and Newsletters.md
@@ -62,9 +62,12 @@ some of these are on youtube too, i dont really bother separating them. ⭐  rep
 	- Alan Thompson's Life Architect https://lifearchitect.substack.com (note [his credentials sus](https://news.ycombinator.com/item?id=35588974))
 	- Bradley Metrock (Deepgram) https://thisweekinvoice.substack.com/
 	- Carlos's Data Machina https://datamachina.substack.com/
+	- Chip Huyen's [huyenchip.com](https://huyenchip.com/blog/) - infrequent but in-depth essays on AI engineering and ML systems from the author of the O'Reilly AI Engineering book
 	- Conor Bronsdon's [Chain of Thought](https://newsletter.chainofthought.show/) - AI engineering interviews and writeups on agents, evals, and LLMOps
 	- Davis Blalock Arxiv roundup https://dblalock.substack.com/
 	- [Elvis Saravia's NLP Newsletter](https://nlp.elvissaravia.com/) - paper recap
+	- Hamel Husain's [Blog](https://hamel.dev/) - hands-on writeups on LLM evals, error analysis, and shipping AI products
+	- Simon Willison's [Newsletter](https://simonw.substack.com/) - prolific, practical commentary on LLMs, tooling, and prompt injection from the Datasette creator
 	- https://www.supervised.news/ is new but promising quality
 	- https://nextword.substack.com/ is new but promising quality
 	- https://www.aitidbits.ai/about is new  but promising quality


### PR DESCRIPTION
Adds four newsletters to Newsletters > Commentators/ML Eng's, all written by individual practitioners. Placed in roughly alphabetical order to match the section.

- Chip Huyen's blog (https://huyenchip.com/blog/) - in-depth essays on AI system design from the author of O'Reilly's AI Engineering.
- Chain of Thought (https://newsletter.chainofthought.show/) - interviews and writeups on agents, evals, and LLMOps. Disclosure: this is my newsletter.
- Hamel Husain's blog (https://hamel.dev/) - hands-on writeups on LLM evals, error analysis, and shipping AI products.
- Simon Willison's newsletter (https://simonw.substack.com/) - prolific practical commentary on LLMs, tooling, and prompt injection from the Datasette creator.

All four are active in 2026 and none were already on the list. Single-line entries matching the neighboring format.